### PR TITLE
Correções no docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,28 +8,38 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+    networks:
+      - rinha
     environment:
-      - DB_HOST=localhost
-      - DB_PORT=3307
+      - DB_HOST=mysql
+      - DB_PORT=3306
       - DB_USERNAME=root
       - DB_PASSWORD=rinhasenha
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
   mysql:
     image: "mysql:8.0"
-    container_name: "mysql_1_F"
+    networks:
+      - rinha
     ports:
-      - "3307:3307"
+      - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=rinhasenha
       - MYSQL_DATABASE=rinha
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
     deploy:
       resources:
         limits:
           cpus: "1"
           memory: "200MB"
+
 networks:
-  default:
+  rinha:
     driver: bridge
-    name: rinha-nginx-2024q1


### PR DESCRIPTION
Tudo bom? Achei mais fácil abrir um PR com as correções que fica mais fácil do que explicar pelo twitter kkkkkk

1. O mysql usa a porta 3306 e você está usando a 3307. Se você quer usar a 3307 tem alterar o "ports" do mysql no seu compose `<host_port>:<container_port>`. Eu deixei a porta 3306 para facilitar.
2. Criei um network e estou usando ele nos serviços pelo `networks:`
3. Coloquei um condição no serviço `api` para subir somente quando o serviço `mysql` estiver pronto. As vezes a sua `api` estava subindo e retornava erro pois o banco de dados ainda não estava pronto. 
4. Como agora tem um network, o `DB_HOST` para acessar o banco passa a ser o nome do serviço que é `mysql`. Você pode alterar esse host pelo `hoststname` 